### PR TITLE
Phase 5 network settings to increase write size to 128 KiB

### DIFF
--- a/staged-public.json
+++ b/staged-public.json
@@ -1,5 +1,5 @@
 {
-  "upgrade": "RLbia1IXamHaOQumuRLxjtIFETj+sD5vKVWXOU2cKq5wFVyjG23MIdHQvKdhwZC6vW9zkTbHY54d75tz/mKPvA==",
-  "timestamp": "2024-08-20T17:00:00Z"
+  "upgrade": "WoaA5FBiiZWLx8hFUA/RtCqKGj/eT/l7Fvo+9TqJYv0qurnNzvEpXO7yUzlvGe+HBw6ZbV4UPmVuWo/QG49oTA==",
+  "timestamp": "2024-10-07T17:00:00Z"
 }
 


### PR DESCRIPTION
Proposing these new limits,
```

Contract limit:
contract_max_size_bytes 64KiB -> 128KiB

Tx limit:
Tx_max_write_bytes 65 KiB -> 129 KiB 
tx_max_size_bytes 70 KiB -> 129 KiB

Ledger limit:
Ledger_max_write_bytes 70 KiB -> 140 KiB
Ledger_max_txs_size_bytes 70 KiB -> 130 KiB

State archival limit:
eviction_scan_size 100 KB -> 500 KB

```